### PR TITLE
🐛 hotfix invalid maxscore

### DIFF
--- a/constants/titles/titles.ts
+++ b/constants/titles/titles.ts
@@ -95,14 +95,14 @@ export const jobs: Job[] = [
     level: 6,
     family: JobFamily.SME,
     minPoints: levelsToPoints["6.1"],
-    maxPoints: levelsToPoints["7.1"],
+    maxPoints: levelsToPoints["7.3"],
   },
   {
     label: "Distinguished Engineer",
     level: 7,
     family: JobFamily.SWE,
     minPoints: levelsToPoints["7.1"],
-    maxPoints: levelsToPoints["8.1"],
+    maxPoints: levelsToPoints["8.3"],
   },
   {
     label: "VP of Engineering",

--- a/constants/titles/titles.ts
+++ b/constants/titles/titles.ts
@@ -95,7 +95,7 @@ export const jobs: Job[] = [
     level: 6,
     family: JobFamily.SME,
     minPoints: levelsToPoints["6.1"],
-    maxPoints: levelsToPoints["7.3"],
+    maxPoints: levelsToPoints["7.1"],
   },
   {
     label: "Distinguished Engineer",
@@ -109,6 +109,6 @@ export const jobs: Job[] = [
     level: 7,
     family: JobFamily.SME,
     minPoints: levelsToPoints["7.1"],
-    maxPoints: levelsToPoints["8.1"],
+    maxPoints: levelsToPoints["8.3"],
   },
 ];


### PR DESCRIPTION
- Acing all points with a speciality results in the role field being set to Engineer I. This is due to the max score of the highest levels being less than the max achievable score. 
- This PR fixes this issue by setting the max title score to the max absolute score